### PR TITLE
respond to 4903 (deleted session)

### DIFF
--- a/AEPAssurance/Source/AssuranceConnectionError.swift
+++ b/AEPAssurance/Source/AssuranceConnectionError.swift
@@ -22,6 +22,7 @@ enum AssuranceConnectionError {
     case orgIDMismatch
     case connectionLimit
     case eventLimit
+    case deletedSession
     case clientError
     case userCancelled
 
@@ -53,6 +54,9 @@ enum AssuranceConnectionError {
                     "You have reached the maximum number of events (10k) that can be sent per minute.", false)
         // todo immediate:  check with the team on better description.
         // todo later:  have griffon server return error description and how to solve... Same for connection & event limit errors
+        case .deletedSession:
+            return ("Session Deleted",
+                    "You attempted to connect to a deleted session.", false)
         case .clientError:
             return ("Client Disconnected",
                     "This client has been disconnected due to an unexpected error. Error Code 4400.", false)

--- a/AEPAssurance/Source/AssuranceConstants.swift
+++ b/AEPAssurance/Source/AssuranceConstants.swift
@@ -131,6 +131,7 @@ enum AssuranceConstants {
         static let ORG_MISMATCH = 4900
         static let CONNECTION_LIMIT = 4901
         static let EVENTS_LIMIT = 4902
+        static let DELETED_SESSSION = 4903
         static let CLIENT_ERROR = 4400
     }
 

--- a/AEPAssurance/Source/AssuranceSession+SocketDelegate.swift
+++ b/AEPAssurance/Source/AssuranceSession+SocketDelegate.swift
@@ -69,6 +69,13 @@ extension AssuranceSession: SocketDelegate {
             handleConnectionError(error: AssuranceConnectionError.eventLimit, closeCode: closeCode)
             break
 
+        // Deleted Session : Close code 4903
+        // Happens when the client connects to a deleted session.
+        // This is a non-retry error. Display the error back to user and close the connection.
+        case AssuranceConstants.SocketCloseCode.DELETED_SESSSION:
+            handleConnectionError(error: AssuranceConnectionError.deletedSession, closeCode: closeCode)
+            break
+
         // Events Limit : Close code 4400
         // This error is generically thrown if the client doesn't adhere to the protocol of the socket connection.
         // For example:

--- a/AEPAssurance/UnitTests/AssuranceConnectionError.swift
+++ b/AEPAssurance/UnitTests/AssuranceConnectionError.swift
@@ -66,6 +66,11 @@ class AssuranceConnectionErrorTests: XCTestCase {
         XCTAssertNotNil(AssuranceConnectionError.userCancelled.info.name)
         XCTAssertNotNil(AssuranceConnectionError.userCancelled.info.description)
         XCTAssertFalse(AssuranceConnectionError.userCancelled.info.shouldRetry)
+        
+        // deleted session error
+        XCTAssertNotNil(AssuranceConnectionError.deletedSession.info.name)
+        XCTAssertNotNil(AssuranceConnectionError.deletedSession.info.description)
+        XCTAssertFalse(AssuranceConnectionError.deletedSession.info.shouldRetry)
 
     }
 }

--- a/AEPAssurance/UnitTests/AssuranceSessionTests.swift
+++ b/AEPAssurance/UnitTests/AssuranceSessionTests.swift
@@ -344,6 +344,23 @@ class AssuranceSessionTests: XCTestCase {
         XCTAssertTrue(mockPinPad.connectionFailedWithErrorCalled)
         XCTAssertEqual(AssuranceConnectionError.clientError, mockPinPad.connectionFailedWithErrorValue)
     }
+    
+    
+    func test_session_whenSocketDisconnect_DeletedSession() throws {
+        // setup
+        session.statusUI = mockStatusUI
+        mockPinPad.isDisplayed = true
+        session.pinCodeScreen = mockPinPad
+
+        // test
+        session.webSocketDidDisconnect(mockSocket, AssuranceConstants.SocketCloseCode.DELETED_SESSSION, "", true)
+
+        // verify
+        XCTAssertTrue(mockStatusUI.removeCalled)
+        XCTAssertTrue(mockPinPad.connectionFailedWithErrorCalled)
+        XCTAssertEqual(AssuranceConnectionError.deletedSession, mockPinPad.connectionFailedWithErrorValue)
+    }
+     
 
     func test_session_whenSocketDisconnect_AbnormalClosure() throws {
         // setup


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When client attempts to connect to deleted session, service sends back 4903, and client should respond correctly and stop sending events. 

## Related Issue

MOB-15576

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Tested by connecting initially to deleted session, and deleting a session while client is still connecting.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
