### PR TITLE
Bugfix stop collecting events after session disconnection

### DIFF
--- a/AEPAssurance/Source/AssuranceEvent.swift
+++ b/AEPAssurance/Source/AssuranceEvent.swift
@@ -14,6 +14,11 @@ import AEPCore
 import AEPServices
 import Foundation
 
+/// Event object used to transport data to/from Assurance server.
+///
+/// This object is intentionally opaque (internal). If this needs to be public,
+/// refactor this class to reflect a builder pattern enforcing size limits on
+/// constituents of the AssuranceEvent like metadata.
 struct AssuranceEvent: Codable {
     var eventID: String = UUID().uuidString
     var vendor: String

--- a/AEPAssurance/Source/AssuranceEventChunker.swift
+++ b/AEPAssurance/Source/AssuranceEventChunker.swift
@@ -55,7 +55,6 @@ struct AssuranceEventChunker {
         }
         var chunkedEvents: [AssuranceEvent] = []
 
-        
         /// The payload is null and the event size exceeds MAX_EVENT_SIZE. This implies that
         /// the metadata is contributing to the event size increase. Metadata currently is data about
         /// chunks. It follows that metadata cannot be chunked. The current logic assumes that

--- a/AEPAssurance/Source/AssuranceEventChunker.swift
+++ b/AEPAssurance/Source/AssuranceEventChunker.swift
@@ -55,8 +55,16 @@ struct AssuranceEventChunker {
         }
         var chunkedEvents: [AssuranceEvent] = []
 
-        /// Highly unlikely to have an event that needs to be chunked without a payload. If so this is an misbehaving event
-        /// We should discard this event and return an empty array in such cases
+        
+        /// The payload is null and the event size exceeds MAX_EVENT_SIZE. This implies that
+        /// the metadata is contributing to the event size increase. Metadata currently is data about
+        /// chunks. It follows that metadata cannot be chunked. The current logic assumes that
+        /// metadata is always within a sane limit (as it is being added internally) and any event
+        /// with a large metadata cannot be handled currently. So, discard this event.
+        /// When Assurance event is publicly instantiable, this assumption about metadata
+        /// does not hold.
+        /// If such a case arises, then the AssuranceEvent creation MUST handle restricting the size
+        /// of metadata accordingly.
         guard let eventPayload = event.payload else {
             Log.warning(label: AssuranceConstants.LOG_TAG, "Discarding the Assurance Event that is demanding to be chunked without a payload. \(event.description)")
             return []

--- a/AEPAssurance/Source/AssuranceSession.swift
+++ b/AEPAssurance/Source/AssuranceSession.swift
@@ -43,12 +43,11 @@ class AssuranceSession {
     /// true indicates Assurance SDK has timeout and shutdown after non-reception of deep link URL because of which it has cleared all the queued initial SDK events from memory.
     var didClearBootEvent: Bool = false
 
-    /// Boolean flag indicating whether to process and queue the SDK events listened from the wildcard listener.
-    /// This flag is set to false on the following occasions
+    /// Boolean flag indicating whether to process and queue the SDK events heard from the wildcard listener.
+    /// This flag is set to false on the following occasions:
     ///  1. When the Assurance extension automatically shuts down on non arrival of assurance deeplink after the 5 second timeout.
     ///  2. When the Assurance session is disconnected by the user.
-    /// This flag is turned back on when
-    ///  1. Assurance extension is reconnected to an new Assurance session
+    /// This flag is turned back on when Assurance extension is reconnected to an new Assurance session
     ///
     /// TODO: MOB-15936
     /// Tracking flags is difficult! This flag should be removed in favor of recreating a

--- a/AEPAssurance/Source/AssuranceSession.swift
+++ b/AEPAssurance/Source/AssuranceSession.swift
@@ -40,8 +40,21 @@ class AssuranceSession {
     /// indicates if Assurance SDK can start forwarding events to the session. This flag is set when a command `startForwarding` is received from the socket.
     var canStartForwarding: Bool = false
 
-    /// true indicates Assurance SDK has timeout and shutdown after non-reception of deep link URL because of which it  has cleared all the queued initial SDK events from memory.
+    /// true indicates Assurance SDK has timeout and shutdown after non-reception of deep link URL because of which it has cleared all the queued initial SDK events from memory.
     var didClearBootEvent: Bool = false
+
+    /// Boolean flag indicating whether to process and queue the SDK events listened from the wildcard listener.
+    /// This flag is set to false on the following occasions
+    ///  1. When the Assurance extension automatically shuts down on non arrival of assurance deeplink after the 5 second timeout.
+    ///  2. When the Assurance session is disconnected by the user.
+    /// This flag is turned back on when
+    ///  1. Assurance extension is reconnected to an new Assurance session
+    ///
+    /// TODO: MOB-15936
+    /// Tracking flags is difficult! This flag should be removed in favor of recreating a
+    /// new AssuranceSession for each new socket connection and making the AssuranceExtension rely
+    /// on the existence of a session for inferring event processing.
+    var canProcessSDKEvents: Bool = true
 
     /// Initializer with instance of  `Assurance` extension
     init(_ assuranceExtension: Assurance) {
@@ -57,6 +70,8 @@ class AssuranceSession {
     /// Otherwise PinCode screen is presented for establishing a new connection.
     ///
     func startSession() {
+        canProcessSDKEvents = true
+
         if socket.socketState == .open || socket.socketState == .connecting {
             Log.debug(label: AssuranceConstants.LOG_TAG, "There is already an ongoing Assurance session. Ignoring to start new session.")
             return
@@ -108,6 +123,7 @@ class AssuranceSession {
     /// Terminates the ongoing Assurance session.
     ///
     func terminateSession() {
+        canProcessSDKEvents = false
         socket.disconnect()
         clearSessionData()
     }
@@ -158,10 +174,11 @@ class AssuranceSession {
     ///
     /// Clears the queued SDK events from memory. Call this method once Assurance shut down timer is triggered.
     ///
-    func clearQueueEvents() {
+    func shutDownSession() {
         inboundQueue.clear()
         outboundQueue.clear()
         didClearBootEvent = true
+        canProcessSDKEvents = false
     }
 
     ///

--- a/AEPAssurance/UnitTests/AssuranceSessionTests.swift
+++ b/AEPAssurance/UnitTests/AssuranceSessionTests.swift
@@ -90,7 +90,7 @@ class AssuranceSessionTests: XCTestCase {
         XCTAssertEqual(2, session.outboundQueue.size())
     }
 
-    func test_session_clearQueueEvents() throws {
+    func test_session_shutDownSession() throws {
         // setup
         session.outboundQueue.enqueue(newElement: sampleAssuranceEvent())
         session.inboundQueue.enqueue(newElement: sampleAssuranceEvent())
@@ -98,12 +98,13 @@ class AssuranceSessionTests: XCTestCase {
         XCTAssertEqual(1, session.inboundQueue.size())
 
         // test
-        session.clearQueueEvents()
+        session.shutDownSession()
 
         // verify
         XCTAssertEqual(0, session.outboundQueue.size())
         XCTAssertEqual(0, session.inboundQueue.size())
         XCTAssertTrue(session.didClearBootEvent)
+        XCTAssertFalse(session.canProcessSDKEvents)
     }
 
     func test_session_outBoundEventsAreQueued_until_socketConnected() throws {
@@ -232,6 +233,7 @@ class AssuranceSessionTests: XCTestCase {
         XCTAssertTrue(mockPlugin.isSessionTerminatedCalled)
         XCTAssertTrue(mockSocket.disconnectCalled)
         XCTAssertFalse(session.canStartForwarding)
+        XCTAssertFalse(session.canProcessSDKEvents)
         XCTAssertNil(assuranceExtension.sessionId)
         XCTAssertNil(assuranceExtension.connectedWebSocketURL)
         XCTAssertEqual(AssuranceConstants.DEFAULT_ENVIRONMENT, assuranceExtension.environment)

--- a/AEPAssurance/UnitTests/AssuranceShutDownTimerTests.swift
+++ b/AEPAssurance/UnitTests/AssuranceShutDownTimerTests.swift
@@ -46,15 +46,17 @@ class AssuranceShutDownTimerTests: XCTestCase {
 
         // test
         assurance.onRegistered()
+        assurance.assuranceSession = mockSession
 
         // verify assurance listens to event before shut down
-        XCTAssertTrue(assurance.shouldProcessEvents)
+        XCTAssertTrue(mockSession.canProcessSDKEvents)
 
         // wait for assurance to shut down
         sleep(2)
 
         // verify assurance is shutdown after timer
-        XCTAssertFalse(assurance.shouldProcessEvents)
+        XCTAssertTrue(mockSession.shutDownSessionCalled)
+        XCTAssertTrue(mockSession.canProcessSDKEvents)
     }
 
     func test_shutDownTimer_invalidated_whenSessionStarted() {
@@ -63,16 +65,19 @@ class AssuranceShutDownTimerTests: XCTestCase {
 
         // test
         assurance.onRegistered()
+        assurance.assuranceSession = mockSession
 
         // verify assurance listens to event before shut down
-        XCTAssertTrue(assurance.shouldProcessEvents)
+        XCTAssertTrue(mockSession.canProcessSDKEvents)
         runtime.simulateComingEvent(event: assuranceStartEvent)
 
         // wait for assurance shutdown timer to run out
         sleep(2)
 
         // verify shutdown timer is invalidated and assurance keeps running
-        XCTAssertTrue(assurance.shouldProcessEvents)
+        XCTAssertTrue(mockSession.canProcessSDKEvents)
+        // verify that the assurance session is not shutdown
+        XCTAssertFalse(mockSession.shutDownSessionCalled)
     }
 
     func test_shutDownTimer_invalidedIfAssuranceReconnecting() {
@@ -81,10 +86,11 @@ class AssuranceShutDownTimerTests: XCTestCase {
 
         // test
         assurance.onRegistered()
+        assurance.assuranceSession = mockSession
         sleep(2)
 
         // verify
-        XCTAssertTrue(assurance.shouldProcessEvents)
+        XCTAssertTrue(mockSession.canProcessSDKEvents)
     }
 
     var assuranceStartEvent: Event {

--- a/AEPAssurance/UnitTests/AssuranceTests.swift
+++ b/AEPAssurance/UnitTests/AssuranceTests.swift
@@ -157,7 +157,7 @@ class AssuranceTests: XCTestCase {
                           type: EventType.analytics,
                           source: EventSource.requestContent,
                           data: nil)
-        assurance.shouldProcessEvents = false
+        mockSession.canProcessSDKEvents = false
 
         // test
         runtime.simulateComingEvent(event: event)

--- a/AEPAssurance/UnitTests/Mocks/MockAssuranceSession.swift
+++ b/AEPAssurance/UnitTests/Mocks/MockAssuranceSession.swift
@@ -44,6 +44,12 @@ class MockAssuranceSession: AssuranceSession {
     override func terminateSession() {
         terminateSessionCalled = true
     }
+    
+    var shutDownSessionCalled = false
+    override func shutDownSession() {
+        shutDownSessionCalled = true
+    }
+
 
     func mockSocketState(state: SocketState) {
         if let mockSocket = socket as? MockSocket {

--- a/TestApp/AppDelegate.swift
+++ b/TestApp/AppDelegate.swift
@@ -48,8 +48,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             MobileCore.configureWith(appId: "")
         })
         MobileCore.lifecycleStart(additionalContextData: nil)
-
-        MobileCore.updateConfigurationWith(configDict: ["experienceCloud.org": "056F3DD059CB22060A494021@AdobeOrg"])
         return true
     }
 

--- a/TestApp/ContentView.swift
+++ b/TestApp/ContentView.swift
@@ -54,7 +54,7 @@ struct YellowButtonStyle: ButtonStyle {
 }
 
 struct AssuranceCard: View {
-    @State private var assuranceURL: String = "assurance://?adb_validation_sessionid=72427e07-b526-4645-bf93-7dafb5c8309a&env=dev"
+    @State private var assuranceURL: String = ""
     var body: some View {
         VStack {
             HStack {


### PR DESCRIPTION
Things that are done in this PR

[Bug FIx] -  stop collecting events after session disconnection
[Docs] - documented the limitation of Assurance metadata usage




Bug reproducing steps:

- Connect to Assurance in your sample app
- Send events, notice they are being displayed in the Assurance UI
- Disconnect from Assurance from the device
- Send more events
- Reconnect to Assurance 

Bug: Notice the events collected during session disconnected are still sent after reconnect
Expectation: No events should be queued or processed after the session is disconnected
