### PR TITLE
Thread safety on Session

### DIFF
--- a/AEPAssurance/UnitTests/Mocks/MockSession.swift
+++ b/AEPAssurance/UnitTests/Mocks/MockSession.swift
@@ -17,30 +17,28 @@ import XCTest
 
 class MockSession: AssuranceSession {
 
-    var expectation: XCTestExpectation?
     override init(sessionDetails: AssuranceSessionDetails, stateManager: AssuranceStateManager, sessionOrchestrator: AssuranceSessionOrchestrator, outboundEvents: ThreadSafeArray<AssuranceEvent>?) {
         super.init(sessionDetails: sessionDetails, stateManager: stateManager, sessionOrchestrator: sessionOrchestrator, outboundEvents: outboundEvents)
-        self.socket = MockSocket(withDelegate: self)
+        self.socket = MockSocket(withDelegate: self)            
     }
 
 
-    var sendEventCalled = false
+    var sendEventCalled = XCTestExpectation(description: "SendEvent method not called")
     var sentEvent: AssuranceEvent?
     override func sendEvent(_ assuranceEvent: AssuranceEvent) {
-        expectation?.fulfill()
-        sendEventCalled = true
+        sendEventCalled.fulfill()
         sentEvent = assuranceEvent
     }
     
-    var startSessionCalled = false
+    var startSessionCalled = XCTestExpectation("startSession method not called")
     override func startSession() {
-        startSessionCalled = true
+        startSessionCalled.fulfill()
     }
 
 
-    var disconnectCalled = false
+    var disconnectCalled = XCTestExpectation("Disconnect method not called")
     override func disconnect() {
-        disconnectCalled = true
+        disconnectCalled.fulfill()
     }
 
     func mockSocketState(state: SocketState) {

--- a/AEPAssurance/UnitTests/Mocks/MockSession.swift
+++ b/AEPAssurance/UnitTests/Mocks/MockSession.swift
@@ -30,13 +30,13 @@ class MockSession: AssuranceSession {
         sentEvent = assuranceEvent
     }
     
-    var startSessionCalled = XCTestExpectation("startSession method not called")
+    var startSessionCalled = XCTestExpectation(description: "startSession method not called")
     override func startSession() {
         startSessionCalled.fulfill()
     }
 
 
-    var disconnectCalled = XCTestExpectation("Disconnect method not called")
+    var disconnectCalled = XCTestExpectation(description: "Disconnect method not called")
     override func disconnect() {
         disconnectCalled.fulfill()
     }

--- a/AEPAssurance/UnitTests/PluginLogForwardingTests.swift
+++ b/AEPAssurance/UnitTests/PluginLogForwardingTests.swift
@@ -129,7 +129,6 @@ class PluginLogForwardingTests: XCTestCase {
 
     func test_commandLogForwarding_completeWorkflow() {
         // setup
-        mockSession.expectation = XCTestExpectation(description: "Sends log event to connected session.")
         plugin.onRegistered(mockSession)
 
         // test
@@ -141,8 +140,7 @@ class PluginLogForwardingTests: XCTestCase {
         os_log("secret log message")
 
         // verify
-        wait(for: [mockSession.expectation!], timeout: 2.0)
-        XCTAssertTrue(mockSession.sendEventCalled)
+        wait(for: [mockSession.sendEventCalled], timeout: 2.0)
         let logEvent = mockSession.sentEvent
         XCTAssertEqual(AssuranceConstants.EventType.LOG, logEvent?.type)
         XCTAssertEqual(AssuranceConstants.Vendor.MOBILE, logEvent?.vendor)
@@ -151,7 +149,9 @@ class PluginLogForwardingTests: XCTestCase {
         XCTAssertTrue(logMessage!.contains("secret log message"))
 
         sleep(1)
-        mockSession.sendEventCalled = false
+        // reset the expectation and invert it to verify that sendEvent is not called
+        mockSession.sendEventCalled = XCTestExpectation()
+        mockSession.sendEventCalled.isInverted = true
 
         // now send event to stop forwarding
         plugin.receiveEvent(logForwardingEvent(start: false))
@@ -161,7 +161,7 @@ class PluginLogForwardingTests: XCTestCase {
 
         // verify
         XCTAssertFalse(plugin.currentlyRunning)
-        XCTAssertFalse(mockSession.sendEventCalled)
+        wait(for: [mockSession.sendEventCalled], timeout: 2.0)
     }
 
     func test_commandLogForwarding_stopForwarding_whenNeverStarted() {
@@ -177,7 +177,6 @@ class PluginLogForwardingTests: XCTestCase {
 
     func test_commandLogForwarding_when_startForwardingReceivedTwice() {
         // setup
-        mockSession.expectation = XCTestExpectation(description: "Sends log event to connected session.")
         plugin.onRegistered(mockSession)
 
         // test
@@ -186,8 +185,7 @@ class PluginLogForwardingTests: XCTestCase {
 
         // verify
         os_log("secret log message")
-        wait(for: [mockSession.expectation!], timeout: 2.0)
-        XCTAssertTrue(mockSession.sendEventCalled)
+        wait(for: [mockSession.sendEventCalled], timeout: 2.0)
     }
 
     func test_unusedProtocolMethod() {

--- a/AEPAssurance/UnitTests/PluginScreenShotTests.swift
+++ b/AEPAssurance/UnitTests/PluginScreenShotTests.swift
@@ -73,7 +73,7 @@ class PluginScreenShotTests: XCTestCase {
         mockNetworkService.completionHandler!(mockConnection)
 
         // verify that the assurance event is sent to the socket
-        XCTAssertTrue(mockSession.sendEventCalled)
+        wait(for: [mockSession.sendEventCalled], timeout: 2.0)
         XCTAssertEqual("mockBlobId", mockSession.sentEvent?.payload?["blobId"])
         XCTAssertEqual("image/png", mockSession.sentEvent?.payload?["mimeType"])
     }
@@ -106,6 +106,7 @@ class PluginScreenShotTests: XCTestCase {
         // setup
         mockUIUtil.mockImageData = sampleImageData
         plugin.onRegistered(mockSession)
+        mockSession.sendEventCalled.isInverted = true
 
         // test
         plugin.receiveEvent(screenShotEvent)
@@ -118,7 +119,7 @@ class PluginScreenShotTests: XCTestCase {
         mockNetworkService.completionHandler!(mockConnection)
 
         // verify that the assurance event is not sent
-        XCTAssertFalse(mockSession.sendEventCalled)
+        wait(for: [mockSession.sendEventCalled], timeout: 2.0)
     }
 
 }


### PR DESCRIPTION
- Guard the AssuranceSession variable in AssuranceSessionOrchestrator class
- Update unit tests
