### PR TITLE
feat: Adding tvOS support

### DIFF
--- a/AEPAssurance.podspec
+++ b/AEPAssurance.podspec
@@ -12,6 +12,8 @@ Pod::Spec.new do |s|
   s.author           = "Adobe Experience Platform SDK Team"
   s.source           = { :git => "https://github.com/adobe/aepsdk-assurance-ios.git", :tag => s.version.to_s }
   s.ios.deployment_target = '10.0'
+  s.tvos.deployment_target = '10.0'
+
   s.swift_version = '5.1'
 
   s.pod_target_xcconfig = { 'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES' }

--- a/AEPAssurance.podspec
+++ b/AEPAssurance.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.author           = "Adobe Experience Platform SDK Team"
   s.source           = { :git => "https://github.com/adobe/aepsdk-assurance-ios.git", :tag => s.version.to_s }
   s.ios.deployment_target = '10.0'
-  s.tvos.deployment_target = '10.0'
+  s.tvos.deployment_target = '13.0'
 
   s.swift_version = '5.1'
 

--- a/AEPAssurance/Source/AssuranceClientInfo.swift
+++ b/AEPAssurance/Source/AssuranceClientInfo.swift
@@ -16,7 +16,6 @@ import Foundation
 import UIKit
 
 enum AssuranceClientInfo {
-
     static let PLATFORM_NAME = "Canonical platform name"
     static let DEVICE_NAME = "Device name"
     static let OPERATING_SYSTEM = "Operating system"
@@ -38,13 +37,14 @@ enum AssuranceClientInfo {
     ///
     /// - Returns- A `Dictionary` containing the above mentioned data
     static func getData() -> [String: AnyCodable] {
-        return [AssuranceConstants.ClientInfoKeys.VERSION: AnyCodable.init(AssuranceConstants.EXTENSION_VERSION),
+        return [AssuranceConstants.ClientInfoKeys.VERSION: AnyCodable(AssuranceConstants.EXTENSION_VERSION),
                 AssuranceConstants.ClientInfoKeys.TYPE: "connect",
-                AssuranceConstants.ClientInfoKeys.APP_SETTINGS: AnyCodable.init(readAppSettingData()),
-                AssuranceConstants.ClientInfoKeys.DEVICE_INFO: AnyCodable.init(readDeviceInfo())]
+                AssuranceConstants.ClientInfoKeys.APP_SETTINGS: AnyCodable(readAppSettingData()),
+                AssuranceConstants.ClientInfoKeys.DEVICE_INFO: AnyCodable(readDeviceInfo())]
     }
 
     // MARK: - Private helper methods
+
     /// - Returns: A `Dictionary` containing the app's Info.plist data
     private static func readAppSettingData() -> NSDictionary {
         var appSettingsInDictionary: NSDictionary = [:]
@@ -62,7 +62,7 @@ enum AssuranceClientInfo {
         var deviceInfo: [String: Any] = [:]
         deviceInfo[PLATFORM_NAME] = PLATFORM_IOS
         deviceInfo[DEVICE_NAME] = UIDevice.current.name
-        deviceInfo[OPERATING_SYSTEM] = ("\(systemInfoService.getOperatingSystemName()) \(systemInfoService.getOperatingSystemVersion())")
+        deviceInfo[OPERATING_SYSTEM] = "\(systemInfoService.getOperatingSystemName()) \(systemInfoService.getOperatingSystemVersion())"
         deviceInfo[DEVICE_TYPE] = getDeviceType()
         deviceInfo[MODEL] = systemInfoService.getDeviceModelNumber()
         deviceInfo[SCREEN_SIZE] = "\(screenSize.width)x\(screenSize.height)"
@@ -79,8 +79,12 @@ enum AssuranceClientInfo {
     ///
     /// - Returns: An `Int` representing the battery level of the device
     private static func getBatteryLevel() -> Int {
-        let batteryPercentage = Int(UIDevice.current.batteryLevel * 100)
-        return (batteryPercentage) > 0 ? batteryPercentage : -1
+        #if os(iOS)
+            let batteryPercentage = Int(UIDevice.current.batteryLevel * 100)
+            return (batteryPercentage) > 0 ? batteryPercentage : -1
+        #else
+            return -1
+        #endif
     }
 
     /// - Returns: A `String` representing the device's location authorization status
@@ -120,5 +124,4 @@ enum AssuranceClientInfo {
             return "Unspecified"
         }
     }
-
 }

--- a/AEPAssurance/Source/AssuranceConstants.swift
+++ b/AEPAssurance/Source/AssuranceConstants.swift
@@ -25,6 +25,9 @@ enum AssuranceConstants {
     enum Deeplink {
         static let SESSIONID_KEY = "adb_validation_sessionid"
         static let ENVIRONMENT_KEY = "env"
+        #if os(tvOS)
+            static let PASSCODE_KEY = "code"
+        #endif
     }
 
     enum SharedStateName {
@@ -79,6 +82,9 @@ enum AssuranceConstants {
         static let ENVIRONMENT = "assurance.environment"
         static let SOCKETURL = "assurance.socketurl"
         static let CONFIG_MODIFIED_KEYS = "assurance.control.modifiedConfigKeys"
+        #if os(tvOS)
+            static let PASSCODE = "assurance.passcode"
+        #endif
     }
 
     enum SharedStateKeys {

--- a/AEPAssurance/Source/AssuranceSession+EventHandler.swift
+++ b/AEPAssurance/Source/AssuranceSession+EventHandler.swift
@@ -14,14 +14,13 @@ import AEPServices
 import Foundation
 
 extension AssuranceSession {
-
     ///
     /// Sends a clientInfo event to the connection session.
     ///
     func sendClientInfoEvent() {
         Log.debug(label: AssuranceConstants.LOG_TAG, "Sending client info event to Assurance")
-        let clientEvent = AssuranceEvent.init(type: AssuranceConstants.EventType.CLIENT, payload: AssuranceClientInfo.getData())
-        self.socket.sendEvent(clientEvent)
+        let clientEvent = AssuranceEvent(type: AssuranceConstants.EventType.CLIENT, payload: AssuranceClientInfo.getData())
+        socket.sendEvent(clientEvent)
     }
 
     ///
@@ -72,8 +71,10 @@ extension AssuranceSession {
                     // 2. Share the Assurance shared state
                     // 3. Notify the client plugins on successful connection
                     self.pinCodeScreen?.connectionSucceeded()
-                    self.statusUI.display()
-                    self.statusUI.updateForSocketConnected()
+                    #if os(iOS)
+                        self.statusUI.display()
+                        self.statusUI.updateForSocketConnected()
+                    #endif
                     self.pluginHub.notifyPluginsOnConnect()
                     self.outboundSource.add(data: 1)
 
@@ -95,5 +96,4 @@ extension AssuranceSession {
         })
         inboundSource.resume()
     }
-
 }

--- a/AEPAssurance/Source/AssuranceSession+SocketDelegate.swift
+++ b/AEPAssurance/Source/AssuranceSession+SocketDelegate.swift
@@ -22,7 +22,7 @@ extension AssuranceSession: SocketDelegate {
     ///
     func webSocketDidConnect(_ socket: SocketConnectable) {
         Log.debug(label: AssuranceConstants.LOG_TAG, "Assurance session successfully connected.")
-        self.sendClientInfoEvent()
+        sendClientInfoEvent()
     }
 
     ///
@@ -33,19 +33,21 @@ extension AssuranceSession: SocketDelegate {
     ///     - reason: A `String` description for the reason for socket disconnection
     ///     - wasClean: A boolean representing if the connection has been terminated successfully. A false value represents the socket connection can be attempted to reconnected.
     func webSocketDidDisconnect(_ socket: SocketConnectable, _ closeCode: Int, _ reason: String, _ wasClean: Bool) {
-
-        // Adding client log so user knows the reason for disconnection
-        statusUI.addClientLog("Assurance Session disconnected : <br> &emsp; close code: \(closeCode) <br> &emsp; reason: \(reason) <br> &emsp; isClean : \(wasClean) ", visibility: .low)
+        #if os(iOS)
+            // Adding client log so user knows the reason for disconnection
+            statusUI.addClientLog("Assurance Session disconnected : <br> &emsp; close code: \(closeCode) <br> &emsp; reason: \(reason) <br> &emsp; isClean : \(wasClean) ", visibility: .low)
+        #endif
 
         switch closeCode {
-
         // Normal Closure : Close code 4900
         // Happens when user disconnects hitting the disconnect button in Status UI.
         // notify plugin on normal closure
         case AssuranceConstants.SocketCloseCode.NORMAL_CLOSURE:
             Log.debug(label: AssuranceConstants.LOG_TAG, "Socket disconnected successfully with close code \(closeCode). Normal closure of websocket.")
             pinCodeScreen?.connectionFinished()
-            statusUI.remove()
+            #if os(iOS)
+                statusUI.remove()
+            #endif
             pluginHub.notifyPluginsOnDisconnect(withCloseCode: closeCode)
 
         // ORG Mismatch : Close code 4900
@@ -105,7 +107,9 @@ extension AssuranceSession: SocketDelegate {
             if !isAttemptingToReconnect {
                 isAttemptingToReconnect = true
                 canStartForwarding = false // set this to false so that all the events are held up until client event is sent after successful reconnect
-                statusUI.updateForSocketInActive()
+                #if os(iOS)
+                    statusUI.updateForSocketInActive()
+                #endif
                 pluginHub.notifyPluginsOnDisconnect(withCloseCode: closeCode)
             }
 
@@ -146,5 +150,4 @@ extension AssuranceSession: SocketDelegate {
             assuranceExtension.connectedWebSocketURL = socket.socketURL?.absoluteString
         }
     }
-
 }

--- a/AEPAssurance/Source/AssuranceSession.swift
+++ b/AEPAssurance/Source/AssuranceSession.swift
@@ -126,9 +126,26 @@ class AssuranceSession {
                 pinCodeScreen.connectionInitialized()
             })
         #elseif os(tvOS)
-            guard let socketURLString = UserDefaults.standard.string(forKey: "AEPAssurance_socket_url"),
-                  let socketURL = URL(string: socketURLString) else {
-                Log.debug(label: AssuranceConstants.LOG_TAG, "SocketURL to connect to session is empty. Ignoring to start Assurance session.")
+            func getURLEncodedOrgID() -> String? {
+                let configState = assuranceExtension.runtime.getSharedState(extensionName: AssuranceConstants.SharedStateName.CONFIGURATION, event: nil, barrier: false)
+                let orgID = configState?.value?[AssuranceConstants.EventDataKey.CONFIG_ORG_ID] as? String
+                return orgID?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+            }
+
+            guard let sessionId = assuranceExtension.sessionId,
+                  let passcode = assuranceExtension.passcode,
+                  let orgID = getURLEncodedOrgID() else {
+                return
+            }
+
+            let socketURLString = String(format: AssuranceConstants.BASE_SOCKET_URL,
+                                         assuranceExtension.environment.urlFormat,
+                                         sessionId,
+                                         passcode,
+                                         orgID,
+                                         assuranceExtension.clientID)
+
+            guard let socketURL = URL(string: socketURLString) else {
                 return
             }
 

--- a/AEPAssurance/Source/AssuranceSession.swift
+++ b/AEPAssurance/Source/AssuranceSession.swift
@@ -26,7 +26,7 @@ class AssuranceSession {
     lazy var socket: SocketConnectable = {
         #if os(iOS)
             WebViewSocket(withDelegate: self)
-        #else
+        #elseif os(tvOS)
             NativeSocket(withDelegate: self)
         #endif
     }()

--- a/AEPAssurance/Source/AssuranceSession.swift
+++ b/AEPAssurance/Source/AssuranceSession.swift
@@ -25,15 +25,15 @@ class AssuranceSession {
 
     lazy var socket: SocketConnectable = {
         #if os(iOS)
-            WebViewSocket(withDelegate: self)
+            return WebViewSocket(withDelegate: self)
         #elseif os(tvOS)
-            NativeSocket(withDelegate: self)
+            return NativeSocket(withDelegate: self)
         #endif
     }()
 
     #if os(iOS)
         lazy var statusUI: iOSStatusUI = {
-            iOSStatusUI.init(withSession: self)
+            return iOSStatusUI.init(withSession: self)
         }()
     #endif
 

--- a/AEPAssurance/Source/ErrorUI/ErrorView.swift
+++ b/AEPAssurance/Source/ErrorUI/ErrorView.swift
@@ -10,64 +10,65 @@
  governing permissions and limitations under the License.
  */
 
-import AEPServices
-import Foundation
-import WebKit
+#if os(iOS)
+    import AEPServices
+    import Foundation
+    import WebKit
 
-class ErrorView: FullscreenMessageDelegate {
+    class ErrorView: FullscreenMessageDelegate {
+        var error: AssuranceConnectionError
+        var fullscreenMessage: FullscreenPresentable?
 
-    var error: AssuranceConnectionError
-    var fullscreenMessage: FullscreenPresentable?
-    var fullscreenWebView: WKWebView?
+        var fullscreenWebView: WKWebView?
 
-    /// Initializer
-    init(_ error: AssuranceConnectionError) {
-        self.error = error
-    }
+        /// Initializer
+        init(_ error: AssuranceConnectionError) {
+            self.error = error
+        }
 
-    func display() {
-        fullscreenMessage = ServiceProvider.shared.uiService.createFullscreenMessage(payload: String(bytes: PinDialogHTML.content, encoding: .utf8) ?? "", listener: self, isLocalImageUsed: false)
-        fullscreenMessage?.show()
-    }
+        func display() {
+            fullscreenMessage = ServiceProvider.shared.uiService.createFullscreenMessage(payload: String(bytes: PinDialogHTML.content, encoding: .utf8) ?? "", listener: self, isLocalImageUsed: false)
+            fullscreenMessage?.show()
+        }
 
-    func onShow(message: FullscreenMessage) {
-        fullscreenWebView = message.webView as? WKWebView
-    }
+        func onShow(message: FullscreenMessage) {
+            fullscreenWebView = message.webView as? WKWebView
+        }
 
-    func onDismiss(message: FullscreenMessage) {
-        fullscreenWebView = nil
-        fullscreenMessage = nil
-    }
+        func onDismiss(message: FullscreenMessage) {
+            fullscreenWebView = nil
+            fullscreenMessage = nil
+        }
 
-    func overrideUrlLoad(message: FullscreenMessage, url: String?) -> Bool {
-        // no operation if we are unable to find the host of the url
-        // return true, so force core to handle the URL
-        guard let host = URL(string: url ?? "")?.host else {
+        func overrideUrlLoad(message: FullscreenMessage, url: String?) -> Bool {
+            // no operation if we are unable to find the host of the url
+            // return true, so force core to handle the URL
+            guard let host = URL(string: url ?? "")?.host else {
+                return true
+            }
+
+            // when the user hits "Cancel" on the iOS pinpad screen. Dismiss the fullscreen message
+            // return false, to indicate that the URL has been handled
+            if host == AssuranceConstants.HTMLURLPath.CANCEL {
+                message.dismiss()
+                return false
+            }
+
             return true
         }
 
-        // when the user hits "Cancel" on the iOS pinpad screen. Dismiss the fullscreen message
-        // return false, to indicate that the URL has been handled
-        if host == AssuranceConstants.HTMLURLPath.CANCEL {
-            message.dismiss()
-            return false
+        func webViewDidFinishInitialLoading(webView: WKWebView) {
+            showErrorDialogToUser()
         }
 
-        return true
-    }
+        func onShowFailure() {
+            Log.debug(label: AssuranceConstants.LOG_TAG, "Unable to display Assurance error screen. Assurance session terminated.")
+        }
 
-    func webViewDidFinishInitialLoading(webView: WKWebView) {
-        showErrorDialogToUser()
+        private func showErrorDialogToUser() {
+            Log.debug(label: AssuranceConstants.LOG_TAG, String(format: "Assurance connection establishment failed. Error : %@, Description : %@", error.info.name, error.info.description))
+            let jsFunctionCall = String(format: "showError('%@','%@', %d);", error.info.name, error.info.description, false)
+            fullscreenWebView?.evaluateJavaScript(jsFunctionCall, completionHandler: nil)
+        }
     }
-
-    func onShowFailure() {
-        Log.debug(label: AssuranceConstants.LOG_TAG, "Unable to display Assurance error screen. Assurance session terminated.")
-    }
-
-    private func showErrorDialogToUser() {
-        Log.debug(label: AssuranceConstants.LOG_TAG, String(format: "Assurance connection establishment failed. Error : %@, Description : %@", error.info.name, error.info.description))
-        let jsFunctionCall = String(format: "showError('%@','%@', %d);", error.info.name, error.info.description, false)
-        fullscreenWebView?.evaluateJavaScript(jsFunctionCall, completionHandler: nil)
-    }
-
-}
+#endif

--- a/AEPAssurance/Source/Extensions/URL+Parser.swift
+++ b/AEPAssurance/Source/Extensions/URL+Parser.swift
@@ -33,4 +33,19 @@ extension URL {
         }
         return dict
     }
+    
+    /**
+     Appending query string parameters to url
+     */
+    func appending(_ queryItems: [URLQueryItem]) -> URL? {
+        guard var urlComponents = URLComponents(url: self, resolvingAgainstBaseURL: true) else {
+            // URL is not conforming to RFC 3986 (maybe it is only conforming to RFC 1808, RFC 1738, and RFC 2732)
+            return nil
+        }
+        // append the query items to the existing ones
+        urlComponents.queryItems = (urlComponents.queryItems ?? []) + queryItems
+
+        // return the url from new url components
+        return urlComponents.url
+    }
 }

--- a/AEPAssurance/Source/PincodeEntry/iOS/iOSPinCodeScreen+FullScreenDelegate.swift
+++ b/AEPAssurance/Source/PincodeEntry/iOS/iOSPinCodeScreen+FullScreenDelegate.swift
@@ -10,6 +10,7 @@
  governing permissions and limitations under the License.
  */
 
+#if os(iOS)
 import AEPServices
 import Foundation
 import WebKit
@@ -116,3 +117,4 @@ extension iOSPinCodeScreen: FullscreenMessageDelegate {
     }
 
 }
+#endif

--- a/AEPAssurance/Source/PincodeEntry/iOS/iOSPinCodeScreen.swift
+++ b/AEPAssurance/Source/PincodeEntry/iOS/iOSPinCodeScreen.swift
@@ -10,6 +10,7 @@
  governing permissions and limitations under the License.
  */
 
+#if os(iOS)
 import AEPServices
 import Foundation
 import WebKit
@@ -63,3 +64,4 @@ class iOSPinCodeScreen: SessionAuthorizingUI {
         fullscreenMessage?.show()
     }
 }
+#endif

--- a/AEPAssurance/Source/Plugin/PluginConfigModify.swift
+++ b/AEPAssurance/Source/Plugin/PluginConfigModify.swift
@@ -26,7 +26,6 @@ import Foundation
 /// The modified configuration keys are stored in datastore, hence when assurance session is terminated the modified configuration is
 /// reverted back.
 class PluginConfigModify: AssurancePlugin {
-
     weak var session: AssuranceSession?
 
     let datastore = NamedCollectionDataStore(name: AssuranceConstants.EXTENSION_NAME)
@@ -54,10 +53,12 @@ class PluginConfigModify: AssurancePlugin {
 
         MobileCore.updateConfigurationWith(configDict: commandDetails)
         var logString = "Configuration updated for \(commandDetails.count > 1 ? "keys" : "key")"
-        for (configKey) in commandDetails.keys {
+        for configKey in commandDetails.keys {
             logString.append("<br> &emsp; \(configKey)")
         }
-        session?.statusUI.addClientLog(logString, visibility: .high)
+        #if os(iOS)
+            session?.statusUI.addClientLog(logString, visibility: .high)
+        #endif
         saveModifiedConfigKeys(commandDetails)
     }
 
@@ -112,5 +113,4 @@ class PluginConfigModify: AssurancePlugin {
     private func clearModifiedKeys() {
         datastore.remove(key: AssuranceConstants.DataStoreKeys.CONFIG_MODIFIED_KEYS)
     }
-
 }

--- a/AEPAssurance/Source/Public/Assurance+PublicAPI.swift
+++ b/AEPAssurance/Source/Public/Assurance+PublicAPI.swift
@@ -15,6 +15,24 @@ import AEPServices
 import Foundation
 
 @objc public extension Assurance {
+    #if os(tvOS)
+        /// Starts an AEPAssurance session for tvOS.
+        ///
+        /// Calling this method when a session has already been started results in a no-op, otherwise it attempts to initiate a new AEPAssurance session.
+        /// A call to this API with an non griffon session url will be ignored
+        ///
+        /// - Parameter url: a valid AEPAssurance URL to start a session
+        /// - Parameter code: code related to the AEPAssurance URL
+        ///
+        static func startSession(url: URL?, code: String? = nil) {
+            var sessionUrl: URL?
+            if let code = code,
+               let updatedUrl = url?.appending([URLQueryItem(name: "code", value: code)]) {
+                sessionUrl = updatedUrl
+            }
+            startSession(url: sessionUrl)
+        }
+    #endif
 
     /// Starts an AEPAssurance session.
     ///
@@ -43,5 +61,4 @@ import Foundation
 
         MobileCore.dispatch(event: event)
     }
-
 }

--- a/AEPAssurance/Source/Socket/Native/NativeSocket.swift
+++ b/AEPAssurance/Source/Socket/Native/NativeSocket.swift
@@ -10,124 +10,122 @@
  governing permissions and limitations under the License.
  */
 
-// NativeSocket will be uncommented and included during Assurance support for TVOS.
 
-// import AEPServices
-// import Foundation
-// import WebKit
-//
-// @available(iOS 13.0, *)
-// class NativeSocket: NSObject, SocketConnectable, URLSessionDelegate, URLSessionWebSocketDelegate {
-//    var socketURL: URL?
-//
-//    var delegate: SocketDelegate
-//    var socketState: SocketState = .unknown {
-//        didSet {
-//            delegate.webSocket(self, didChangeState: self.socketState)
-//        }
-//    }
-//
-//    // MARK: - Private properties
-//
-//    private var session: URLSession?
-//    private var socketTask: URLSessionWebSocketTask?
-//
-//    // MARK: - SocketConnectable Interfaces
-//
-//    /// Initialization of native socket connection.
-//    /// - Parameters:
-//    ///     - delegate: the delegate instance to get notified on essential socket events
-//    required init(withDelegate delegate: SocketDelegate) {
-//        self.delegate = delegate
-//    }
-//
-//    /// Makes a socket connection with the provided URL
-//    /// Sets the socket state to `CONNECTING` and attempts to make a connection.
-//    /// On successful connection the socketDelegate's `webSocketDidConnect` method is invoked. And the socket state is set to `OPEN`.
-//    /// On any error,  the socketDelegate `webSocketOnError` method is invoked.
-//    /// - Parameters :
-//    ///     - url : the socket `URL`
-//    func connect(withUrl url: URL) {
-//        session = URLSession(configuration: .default, delegate: self, delegateQueue: OperationQueue())
-//        socketTask = session?.webSocketTask(with: url)
-//        socketTask?.resume()
-//        registerCallbacks()
-//        socketState = .connecting
-//    }
-//
-//    /// Disconnect the ongoing socket connection.
-//    /// Sets the socket state to `CLOSING` and attempts for disconnection
-//    /// On successful disconnection  the socketDelegate's `webSocketDidDisconnect`method is invoked. And the socket state is set to`CLOSED`.
-//    /// On any error,  the socketDelegate's `webSocketOnError`method is invoked.
-//    func disconnect() {
-//        socketState = .closing
-//        socketTask?.cancel(with: .normalClosure, reason: nil)
-//    }
-//
-//    func sendEvent(_ event: AssuranceEvent) {
-//        let encoder = JSONEncoder()
-//        encoder.dateEncodingStrategy = .millisecondsSince1970
-//        let jsonData = (try? encoder.encode(event)) ?? Data()
-//        let dataString = jsonData.base64EncodedString(options: .endLineWithLineFeed)
-//        socketTask?.send(URLSessionWebSocketTask.Message.string(dataString), completionHandler: { [weak self] error in
-//            if let error = error {
-//                self?.didReceiveError(error)
-//            }
-//        })
-//    }
-//
-//    // MARK: - URLSessionWebSocketDelegate methods
-//
-//    func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didOpenWithProtocol protocol: String?) {
-//        socketState = .open
-//        self.delegate.webSocketDidConnect(self)
-//    }
-//
-//    func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didCloseWith closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
-//        socketState = .closed
-//        self.delegate.webSocketDidDisconnect(self, closeCode.rawValue, reason?.base64EncodedString() ?? "", true)
-//    }
-//
-//    // MARK: - Private methods
-//
-//    private func registerCallbacks() {
-//        socketTask?.receive {[weak self] result in
-//            switch result {
-//            case .success(let response):
-//                switch response {
-//                case .string(let message):
-//                    self?.didReceiveMessage(message)
-//                case .data(let data):
-//                    self?.didReceiveBinaryData(data)
-//                @unknown default:
-//                    Log.debug(label: AssuranceConstants.LOG_TAG, "Unknown format data received from socket. Ignoring incoming event")
-//                }
-//            case .failure(let error):
-//                self?.didReceiveError(error)
-//            }
-//        }
-//    }
-//
-//    /// Handle the error from socket connection
-//    private func didReceiveError(_ error: Error) {
-//        self.delegate.webSocketOnError(self)
-//    }
-//
-//    /// Handle the incoming string message from socket
-//    private func didReceiveMessage(_ message: String) {
-//        guard let data = message.data(using: .utf8) else {
-//            Log.debug(label: AssuranceConstants.LOG_TAG, "Unable to convert the received socket message to data. Ignoring the incoming event.")
-//            return
-//        }
-//        guard let receivedEvent = AssuranceEvent.from(jsonData: data) else {
-//            return
-//        }
-//        self.delegate.webSocket(self, didReceiveEvent: receivedEvent)
-//    }
-//
-//    /// Handle the incoming binary data from socket
-//    private func didReceiveBinaryData(_ data: Data) {
-//        Log.debug(label: AssuranceConstants.LOG_TAG, "Assurance SDK cannot to handle binary data received from socket.")
-//    }
-//
-// }
+ import AEPServices
+ import Foundation
+
+ @available(iOS 13.0, *)
+ class NativeSocket: NSObject, SocketConnectable, URLSessionDelegate, URLSessionWebSocketDelegate {
+    var socketURL: URL?
+
+    var delegate: SocketDelegate
+    var socketState: SocketState = .unknown {
+        didSet {
+            delegate.webSocket(self, didChangeState: self.socketState)
+        }
+    }
+
+    // MARK: - Private properties
+
+    private var session: URLSession?
+    private var socketTask: URLSessionWebSocketTask?
+
+    // MARK: - SocketConnectable Interfaces
+
+    /// Initialization of native socket connection.
+    /// - Parameters:
+    ///     - delegate: the delegate instance to get notified on essential socket events
+    required init(withDelegate delegate: SocketDelegate) {
+        self.delegate = delegate
+    }
+
+    /// Makes a socket connection with the provided URL
+    /// Sets the socket state to `CONNECTING` and attempts to make a connection.
+    /// On successful connection the socketDelegate's `webSocketDidConnect` method is invoked. And the socket state is set to `OPEN`.
+    /// On any error,  the socketDelegate `webSocketOnError` method is invoked.
+    /// - Parameters :
+    ///     - url : the socket `URL`
+    func connect(withUrl url: URL) {
+        session = URLSession(configuration: .default, delegate: self, delegateQueue: OperationQueue())
+        socketTask = session?.webSocketTask(with: url)
+        socketTask?.resume()
+        registerCallbacks()
+        socketState = .connecting
+    }
+
+    /// Disconnect the ongoing socket connection.
+    /// Sets the socket state to `CLOSING` and attempts for disconnection
+    /// On successful disconnection  the socketDelegate's `webSocketDidDisconnect`method is invoked. And the socket state is set to`CLOSED`.
+    /// On any error,  the socketDelegate's `webSocketOnError`method is invoked.
+    func disconnect() {
+        socketState = .closing
+        socketTask?.cancel(with: .normalClosure, reason: nil)
+    }
+
+    func sendEvent(_ event: AssuranceEvent) {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .millisecondsSince1970
+        let jsonData = (try? encoder.encode(event)) ?? Data()
+        let dataString = jsonData.base64EncodedString(options: .endLineWithLineFeed)
+        socketTask?.send(URLSessionWebSocketTask.Message.string(dataString), completionHandler: { [weak self] error in
+            if let error = error {
+                self?.didReceiveError(error)
+            }
+        })
+    }
+
+    // MARK: - URLSessionWebSocketDelegate methods
+
+    func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didOpenWithProtocol protocol: String?) {
+        socketState = .open
+        self.delegate.webSocketDidConnect(self)
+    }
+
+    func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didCloseWith closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
+        socketState = .closed
+        self.delegate.webSocketDidDisconnect(self, closeCode.rawValue, reason?.base64EncodedString() ?? "", true)
+    }
+
+    // MARK: - Private methods
+
+    private func registerCallbacks() {
+        socketTask?.receive {[weak self] result in
+            switch result {
+            case .success(let response):
+                switch response {
+                case .string(let message):
+                    self?.didReceiveMessage(message)
+                case .data(let data):
+                    self?.didReceiveBinaryData(data)
+                @unknown default:
+                    Log.debug(label: AssuranceConstants.LOG_TAG, "Unknown format data received from socket. Ignoring incoming event")
+                }
+            case .failure(let error):
+                self?.didReceiveError(error)
+            }
+        }
+    }
+
+    /// Handle the error from socket connection
+    private func didReceiveError(_ error: Error) {
+        self.delegate.webSocketOnError(self)
+    }
+
+    /// Handle the incoming string message from socket
+    private func didReceiveMessage(_ message: String) {
+        guard let data = message.data(using: .utf8) else {
+            Log.debug(label: AssuranceConstants.LOG_TAG, "Unable to convert the received socket message to data. Ignoring the incoming event.")
+            return
+        }
+        guard let receivedEvent = AssuranceEvent.from(jsonData: data) else {
+            return
+        }
+        self.delegate.webSocket(self, didReceiveEvent: receivedEvent)
+    }
+
+    /// Handle the incoming binary data from socket
+    private func didReceiveBinaryData(_ data: Data) {
+        Log.debug(label: AssuranceConstants.LOG_TAG, "Assurance SDK cannot to handle binary data received from socket.")
+    }
+
+ }

--- a/AEPAssurance/Source/Socket/WebView/WebViewSocket.swift
+++ b/AEPAssurance/Source/Socket/WebView/WebViewSocket.swift
@@ -10,6 +10,7 @@
  governing permissions and limitations under the License.
  */
 
+#if os(iOS)
 import AEPServices
 import Foundation
 import WebKit
@@ -231,3 +232,4 @@ class WebViewSocket: NSObject, SocketConnectable, WKNavigationDelegate, WKScript
     }
 
 }
+#endif

--- a/AEPAssurance/Source/StatusUI/iOS/iOSStatusUI+FloatingButtonDelegate.swift
+++ b/AEPAssurance/Source/StatusUI/iOS/iOSStatusUI+FloatingButtonDelegate.swift
@@ -10,6 +10,7 @@
  governing permissions and limitations under the License.
  */
 
+#if os(iOS)
 import AEPServices
 import Foundation
 
@@ -36,3 +37,4 @@ extension iOSStatusUI: FloatingButtonDelegate {
     /// Invoked when the floating button is removed
     func onDismiss() {}
 }
+#endif

--- a/AEPAssurance/Source/StatusUI/iOS/iOSStatusUI+FullScreenDelegate.swift
+++ b/AEPAssurance/Source/StatusUI/iOS/iOSStatusUI+FullScreenDelegate.swift
@@ -10,6 +10,7 @@
  governing permissions and limitations under the License.
  */
 
+#if os(iOS)
 import AEPServices
 import Foundation
 import WebKit
@@ -74,3 +75,4 @@ extension iOSStatusUI: FullscreenMessageDelegate {
         Log.warning(label: AssuranceConstants.LOG_TAG, "Unable to display the statusUI screen, onShowFailure delegate method is invoked")
     }
 }
+#endif

--- a/AEPAssurance/Source/StatusUI/iOS/iOSStatusUI.swift
+++ b/AEPAssurance/Source/StatusUI/iOS/iOSStatusUI.swift
@@ -10,6 +10,7 @@
  governing permissions and limitations under the License.
  */
 
+#if os(iOS)
 import AEPServices
 import Foundation
 import WebKit
@@ -110,3 +111,4 @@ class iOSStatusUI {
     }
 
 }
+#endif


### PR DESCRIPTION
Adding tvOS support to allow using AEPAssurance with tvOS

## Description

Limiting all UI related classes to iOS
Using NativeSocket to connect
Passing session code as additional parameter to be appended to the session url when starting the session. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

This change is requited to be able to see the events being sent to the Analytics platform which is currently available for iOS but not for tvOS.

## How Has This Been Tested?

To start using the Assurance SDK it is usually needed to provide session url, so for tvOS it will also receive the code that was generated for the specific session to start working with it


```
      MobileCore.registerExtension(Assurance.self)

      #if os(tvOS)
         Assurance.startSession(url: url, code: griffonSessionCode)
      #elseif os(iOS)
         Assurance.startSession(url: sessionUrl)
      #endif
```

## Screenshots (if appropriate):
![Screen Shot 1](https://user-images.githubusercontent.com/3462044/173333157-842618d6-456a-479d-b5c9-a7931008d3a1.png)
![Screen Shot 2](https://user-images.githubusercontent.com/3462044/173333167-676aa8ab-5a78-42b4-92ac-cffde1e2b7f3.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
