### PR TITLE
Update QUICK_CONNECT_BASE_URL

### DIFF
--- a/AEPAssurance/Source/AssuranceConstants.swift
+++ b/AEPAssurance/Source/AssuranceConstants.swift
@@ -21,7 +21,7 @@ enum AssuranceConstants {
 
     static let BASE_SOCKET_URL = "wss://connect%@.griffon.adobe.com/client/v1?sessionId=%@&token=%@&orgId=%@&clientId=%@"
     static let SHUTDOWN_TIME = 5
-    static let QUICK_CONNECT_BASE_URL = "https://device.griffon.adobe.com/device/"
+    static let QUICK_CONNECT_BASE_URL = "https://device.griffon.adobe.com/device"
 
     enum Deeplink {
         static let SESSIONID_KEY = "adb_validation_sessionid"


### PR DESCRIPTION
## Description
Update quick connect base url to remove duplicated forward slash at the end

After updating the API on the service side, it doesn't like duplicated forward slash in a request URL (e.g. https://device.griffon.adobe.com/device//create ), hence this PR fixes the problem.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

See description

## How Has This Been Tested?

Tested locally

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
