### PR TITLE
[MOB-17367] Move the CLLocationManager API call off the main thread

### DIFF
--- a/AEPAssurance/Source/AssuranceClientInfo.swift
+++ b/AEPAssurance/Source/AssuranceClientInfo.swift
@@ -66,7 +66,7 @@ enum AssuranceClientInfo {
         deviceInfo[DEVICE_TYPE] = getDeviceType()
         deviceInfo[MODEL] = systemInfoService.getDeviceModelNumber()
         deviceInfo[SCREEN_SIZE] = "\(screenSize.width)x\(screenSize.height)"
-        DispatchQueue.global().async {
+        DispatchQueue.global().sync {
             deviceInfo[LOCATION_SERVICE_ENABLED] = Bool(CLLocationManager.locationServicesEnabled())
         }
         deviceInfo[LOCATION_AUTHORIZATION_STATUS] = getAuthStatusString(authStatus: CLLocationManager.authorizationStatus())

--- a/AEPAssurance/Source/AssuranceClientInfo.swift
+++ b/AEPAssurance/Source/AssuranceClientInfo.swift
@@ -66,7 +66,9 @@ enum AssuranceClientInfo {
         deviceInfo[DEVICE_TYPE] = getDeviceType()
         deviceInfo[MODEL] = systemInfoService.getDeviceModelNumber()
         deviceInfo[SCREEN_SIZE] = "\(screenSize.width)x\(screenSize.height)"
-        deviceInfo[LOCATION_SERVICE_ENABLED] = Bool(CLLocationManager.locationServicesEnabled())
+        DispatchQueue.global().async {
+            deviceInfo[LOCATION_SERVICE_ENABLED] = Bool(CLLocationManager.locationServicesEnabled())
+        }
         deviceInfo[LOCATION_AUTHORIZATION_STATUS] = getAuthStatusString(authStatus: CLLocationManager.authorizationStatus())
         deviceInfo[LOW_POWER_BATTERY_ENABLED] = ProcessInfo.processInfo.isLowPowerModeEnabled
         deviceInfo[BATTERY_LEVEL] = getBatteryLevel()


### PR DESCRIPTION
Xcode gives the warning "This method can cause UI unresponsiveness if invoked on the main thread. Instead, consider waiting for the -locationManagerDidChangeAuthorization: callback and checking authorizationStatus first." when calling `CLLocationManager.locationServicesEnabled()` on the main thread. 

Simply used GCD to put this call on a background thread instead.