### PR TITLE
Add missing debug macros for quickConnect

### DIFF
--- a/AEPAssurance/Source/AssuranceSessionOrchestrator.swift
+++ b/AEPAssurance/Source/AssuranceSessionOrchestrator.swift
@@ -42,7 +42,9 @@ class AssuranceSessionOrchestrator: AssurancePresentationDelegate, AssuranceConn
     
     init(stateManager: AssuranceStateManager) {
         self.stateManager = stateManager
+        #if DEBUG
         self.quickConnectManager = QuickConnectManager(stateManager: stateManager, uiDelegate: self)
+        #endif
         self.outboundEventBuffer = ThreadSafeArray(identifier: "Session Orchestrator's OutboundBuffer array")
     }
 
@@ -67,6 +69,7 @@ class AssuranceSessionOrchestrator: AssurancePresentationDelegate, AssuranceConn
         outboundEventBuffer = nil
     }
     
+    #if DEBUG
     ///
     /// Starts the quick connect flow
     ///
@@ -84,6 +87,7 @@ class AssuranceSessionOrchestrator: AssurancePresentationDelegate, AssuranceConn
         }
         self.authorizingPresentation?.show()
     }
+    #endif
 
     ///
     /// Dissolve the active session (if one exists) and its associated states.

--- a/AEPAssurance/Source/QuickConnect/QuickConnectManager.swift
+++ b/AEPAssurance/Source/QuickConnect/QuickConnectManager.swift
@@ -14,6 +14,10 @@ import Foundation
 import UIKit
 import AEPServices
 
+#if DEBUG
+///
+/// QuickConnectManager manages the QuickConnectService, and passes relevant updates from it to the AssurancePresentationDelegate
+///
 class QuickConnectManager {
 
     private let stateManager: AssuranceStateManager
@@ -84,3 +88,4 @@ class QuickConnectManager {
         quickConnectService.shouldRetryGetDeviceStatus = false
     }
 }
+#endif


### PR DESCRIPTION
We were missing a few debug macro wrappers around some quick connect code which was causing compilation to fail when the framework was included externally. 

This now works, and has been tested with Cocoapods. Archiving works, but it will strip all the debug code, so currently XCFrameworks will not support QuickConnect. (Waiting on Product decision for this)