### PR TITLE
Version bump to 3.1.0

### DIFF
--- a/AEPAssurance.podspec
+++ b/AEPAssurance.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "AEPAssurance"
-  s.version          = "3.0.1"
+  s.version          = "3.1.0"
   s.summary          = "AEPAssurance SDK for Adobe Experience Platform Mobile SDK. Written and maintained by Adobe."
 
   s.description      = <<-DESC

--- a/AEPAssurance/Source/AssuranceConstants.swift
+++ b/AEPAssurance/Source/AssuranceConstants.swift
@@ -15,7 +15,7 @@ import Foundation
 enum AssuranceConstants {
     static let EXTENSION_NAME = "com.adobe.assurance"
     static let FRIENDLY_NAME = "Assurance"
-    static let EXTENSION_VERSION = "3.0.1"
+    static let EXTENSION_VERSION = "3.1.0"
     static let LOG_TAG = FRIENDLY_NAME
     static let DEFAULT_ENVIRONMENT = AssuranceEnvironment.prod
 


### PR DESCRIPTION
Version bump to 3.1.0 in preparation for release which includes:

- QuickConnect (beta) support
- Sanitize Socket URL
- Move CLLocation manager code off main thread