### PR TITLE
version bump to 3.1.1

### DIFF
--- a/AEPAssurance.podspec
+++ b/AEPAssurance.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "AEPAssurance"
-  s.version          = "3.1.0"
+  s.version          = "3.1.1"
   s.summary          = "AEPAssurance SDK for Adobe Experience Platform Mobile SDK. Written and maintained by Adobe."
 
   s.description      = <<-DESC

--- a/AEPAssurance/Source/AssuranceConstants.swift
+++ b/AEPAssurance/Source/AssuranceConstants.swift
@@ -15,7 +15,7 @@ import Foundation
 enum AssuranceConstants {
     static let EXTENSION_NAME = "com.adobe.assurance"
     static let FRIENDLY_NAME = "Assurance"
-    static let EXTENSION_VERSION = "3.1.0"
+    static let EXTENSION_VERSION = "3.1.1"
     static let LOG_TAG = FRIENDLY_NAME
     static let DEFAULT_ENVIRONMENT = AssuranceEnvironment.prod
 


### PR DESCRIPTION
Version bump to 3.1.1 which contains:

- Fixes a bug in Quick Connect where sessions are not properly terminated on socket connection errors.